### PR TITLE
Update as you type.js

### DIFF
--- a/source/as you type.js
+++ b/source/as you type.js
@@ -23,7 +23,6 @@ from './metadata'
 import
 {
 	VALID_PUNCTUATION,
-	PLUS_SIGN,
 	PLUS_CHARS,
 	VALID_DIGITS,
 	extract_formatted_phone_number,


### PR DESCRIPTION
PLUS_SIGN is not exported and actually does not exist in './parse', spotted while trying to use rollup on this lib