### PR TITLE
asYouType: properly defined country phone code on countriness reset

### DIFF
--- a/source/as you type.js
+++ b/source/as you type.js
@@ -400,7 +400,7 @@ export default class as_you_type
 		if (this.default_country && !this.is_international())
 		{
 			this.country_metadata = this.metadata.countries[this.default_country]
-			this.country_phone_code = this.country_metadata.phone_code
+			this.country_phone_code = get_phone_code(this.country_metadata)
 
 			this.initialize_phone_number_formats_for_this_country_phone_code()
 		}

--- a/test/as you type.js
+++ b/test/as you type.js
@@ -276,24 +276,28 @@ describe('as you type', () =>
 		// formatter.valid.should.be.false
 		formatter.template.should.equal('x (xxx) xxx-xx-xx')
 		formatter.country.should.equal('RU')
+		formatter.country_phone_code.should.equal('7')
 
 		formatter.input('000000000000').should.equal('8999000000000000')
 
 		// formatter.valid.should.be.false
 		type(formatter.template).should.equal('undefined')
 		formatter.country.should.equal('RU')
+		formatter.country_phone_code.should.equal('7')
 
 		formatter.reset()
 
 		// formatter.valid.should.be.false
 		type(formatter.template).should.equal('undefined')
 		formatter.country.should.equal('RU')
+		formatter.country_phone_code.should.equal('7')
 
 		formatter.input('+1-213-373-4253').should.equal('+1 213 373 4253')
 
 		// formatter.valid.should.be.true
 		formatter.template.should.equal('xx xxx xxx xxxx')
 		formatter.country.should.equal('US')
+		formatter.country_phone_code.should.equal('1')
 	})
 
 	it('should work in edge cases', function()


### PR DESCRIPTION
Country metadata is an array and not an object, thus while running
reset_countriness, the ountry_phone_code was alway set to undefined,
instead of the default one.

This issue seems to have no impact on the lib behavior, however, this
is annoying for custom behavior as always returning international
partial number.