### PR TITLE
Error #159: Invalid US Phone Numbers with 11 digits are parsed OK

### DIFF
--- a/test/parse.js
+++ b/test/parse.js
@@ -18,6 +18,8 @@ describe('parse', () =>
 		parse('+7 (800) 55-35-35', undefined).should.deep.equal({})
 		parse('+7 (800) 55-35-35', 'US').should.deep.equal({})
 		parse('(800) 55 35 35', { country: { default: 'RU' } }).should.deep.equal({})
+		parse('+1 187 215 5230', 'US').should.deep.equal({}) 
+		parse('+1 1877 215 5230', 'US').should.deep.equal({})
 	})
 
 	it('should parse valid phone numbers', function()


### PR DESCRIPTION
- Added invalid 10 digits US phone number
- Added invalid 11 digits US Phone number