### PR TITLE
Revert "fix #170 - declare PhoneCode (and TelephoneNumber and Extensi…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,9 +2,9 @@ export type CountryCode = 'AD' | 'AE' | 'AF' | 'AG' | 'AI' | 'AL' | 'AM' | 'AO' 
 
 export type NumberFormat = 'National' | 'International' | 'E.164' | 'RFC3966';
 
-export type TelephoneNumber = string
-export type Extension = string
-export type PhoneCode = string
+export interface TelephoneNumber extends String { }
+export interface Extension extends String { }
+export interface PhoneCode extends String { }
 
 export interface ParsedNumber {
     phone: TelephoneNumber,


### PR DESCRIPTION
…on) using `export type XXX = string` instead of `export interface PhoneCode extends String { }`"

This reverts commit 42a4a6c043d4aa73c7a1ef77ef3f9f85f9c03bc5.