### PR TITLE
Fix metadata import for CommonJS

### DIFF
--- a/index.common.js
+++ b/index.common.js
@@ -54,4 +54,4 @@ exports.getCountryCallingCode = function(country)
 // `getPhoneCode` name is deprecated
 exports.getPhoneCode = exports.getCountryCallingCode
 
-exports.Metadata = require('./es6/metadata').default
+exports.Metadata = require('./build/metadata').default


### PR DESCRIPTION
NodeJS currently crashes on the import statements in `./es6/metadata`. Shouldn't it import the built version when using commonJS modules?