### PR TITLE
TypeScript: fixed method signature for searchPhoneNumbers

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -32,7 +32,7 @@ export function findPhoneNumbers(text: string, metadata: object): NumberFound[];
 export function findPhoneNumbers(text: string, options: CountryCode | { defaultCountry?: CountryCode }, metadata: object): NumberFound[];
 
 export function searchPhoneNumbers(text: string, metadata: object): IterableIterator<NumberFound>;
-export function searchPhoneNumbers(text: string, options?: CountryCode | { defaultCountry?: CountryCode }, metadata: object): IterableIterator<NumberFound>;
+export function searchPhoneNumbers(text: string, options?: CountryCode | { defaultCountry?: CountryCode }, metadata?: object): IterableIterator<NumberFound>;
 
 export function getCountryCallingCode(countryCode: CountryCode, metadata: object): CountryCallingCode;
 


### PR DESCRIPTION
This PR fixes the below error caused by an invalid method signature on `searchPhoneNumbers` in `custom.d.ts`

`ERROR in node_modules/libphonenumber-js/custom.d.ts(35,108): error TS1016: A required parameter cannot follow an optional parameter.`

This issue is causing our builds to fail on the latest angular cli

We are working around it by fixing it locally and installing the tarball, but would love it if you could merge this and release an official fix.