### PR TITLE
Document and test `TOO_SHORT` parsePhoneNumber error

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ Returns an instance of [`PhoneNumber`](#phonenumber) class. Throws in case of an
 * `NOT_A_NUMBER` — When no phone number was found. For example, when there are no digits (`"abcde"`) or when there's not enough digits (`parsePhoneNumber('2', 'US')`, `parsePhoneNumber('+1')`).
 
 * `TOO_LONG` — When national (significant) number is too long (17 digits max) or when the string being parsed is too long (250 characters max).
+
+* `TOO_SHORT` — When national (significant) number is too short (for ex. 1 digit).
 </details>
 
 ### `PhoneNumber`

--- a/source/parsePhoneNumber.test.js
+++ b/source/parsePhoneNumber.test.js
@@ -67,6 +67,7 @@ describe('parsePhoneNumber', () => {
 		expect(() => parsePhoneNumber('8', 'RU')).to.throw('NOT_A_NUMBER')
 		// Won't throw here because the regexp already demands length > 1.
 		// expect(() => parsePhoneNumber('11', 'RU')).to.throw('TOO_SHORT')
+		expect(() => parsePhoneNumber('+443')).to.throw('TOO_SHORT')
 		expect(() => parsePhoneNumber('88888888888888888888', 'RU')).to.throw('TOO_LONG')
 		expect(() => parsePhoneNumber('8 (800) 555 35 35')).to.throw('INVALID_COUNTRY')
 		expect(() => parsePhoneNumber('+9991112233')).to.throw('INVALID_COUNTRY')


### PR DESCRIPTION
Hi,

first of all many thanks for writing and sharing this library.

I noticed that `parsePhoneNumber` can (correctly) return a fourth error, `TOO_SHORT`, other than the three currently documented in the README under [possible errors](https://github.com/catamphetamine/libphonenumber-js#parsephonenumberstring-defaultcountry). 

Try this for example:

```js
const { parsePhoneNumber } = require('libphonenumber-js');

// Country code is valid, but number is < 2 digits
const ret = parsePhoneNumber('+443');
// > Error: TOO_SHORT
```

Hence, I added this error to the docs and a further test case to to the relevant test file.
Hope that's alright.

Cheers.
