### PR TITLE
Fix error in typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,17 @@
 export type CountryCode = '001' | 'AC' | 'AD' | 'AE' | 'AF' | 'AG' | 'AI' | 'AL' | 'AM' | 'AO' | 'AR' | 'AS' | 'AT' | 'AU' | 'AW' | 'AX' | 'AZ' | 'BA' | 'BB' | 'BD' | 'BE' | 'BF' | 'BG' | 'BH' | 'BI' | 'BJ' | 'BL' | 'BM' | 'BN' | 'BO' | 'BQ' | 'BR' | 'BS' | 'BT' | 'BW' | 'BY' | 'BZ' | 'CA' | 'CC' | 'CD' | 'CF' | 'CG' | 'CH' | 'CI' | 'CK' | 'CL' | 'CM' | 'CN' | 'CO' | 'CR' | 'CU' | 'CV' | 'CW' | 'CX' | 'CY' | 'CZ' | 'DE' | 'DJ' | 'DK' | 'DM' | 'DO' | 'DZ' | 'EC' | 'EE' | 'EG' | 'EH' | 'ER' | 'ES' | 'ET' | 'FI' | 'FJ' | 'FK' | 'FM' | 'FO' | 'FR' | 'GA' | 'GB' | 'GD' | 'GE' | 'GF' | 'GG' | 'GH' | 'GI' | 'GL' | 'GM' | 'GN' | 'GP' | 'GQ' | 'GR' | 'GT' | 'GU' | 'GW' | 'GY' | 'HK' | 'HN' | 'HR' | 'HT' | 'HU' | 'ID' | 'IE' | 'IL' | 'IM' | 'IN' | 'IO' | 'IQ' | 'IR' | 'IS' | 'IT' | 'JE' | 'JM' | 'JO' | 'JP' | 'KE' | 'KG' | 'KH' | 'KI' | 'KM' | 'KN' | 'KP' | 'KR' | 'KW' | 'KY' | 'KZ' | 'LA' | 'LB' | 'LC' | 'LI' | 'LK' | 'LR' | 'LS' | 'LT' | 'LU' | 'LV' | 'LY' | 'MA' | 'MC' | 'MD' | 'ME' | 'MF' | 'MG' | 'MH' | 'MK' | 'ML' | 'MM' | 'MN' | 'MO' | 'MP' | 'MQ' | 'MR' | 'MS' | 'MT' | 'MU' | 'MV' | 'MW' | 'MX' | 'MY' | 'MZ' | 'NA' | 'NC' | 'NE' | 'NF' | 'NG' | 'NI' | 'NL' | 'NO' | 'NP' | 'NR' | 'NU' | 'NZ' | 'OM' | 'PA' | 'PE' | 'PF' | 'PG' | 'PH' | 'PK' | 'PL' | 'PM' | 'PR' | 'PS' | 'PT' | 'PW' | 'PY' | 'QA' | 'RE' | 'RO' | 'RS' | 'RU' | 'RW' | 'SA' | 'SB' | 'SC' | 'SD' | 'SE' | 'SG' | 'SH' | 'SI' | 'SJ' | 'SK' | 'SL' | 'SM' | 'SN' | 'SO' | 'SR' | 'SS' | 'ST' | 'SV' | 'SX' | 'SY' | 'SZ' | 'TA' | 'TC' | 'TD' | 'TG' | 'TH' | 'TJ' | 'TK' | 'TL' | 'TM' | 'TN' | 'TO' | 'TR' | 'TT' | 'TV' | 'TW' | 'TZ' | 'UA' | 'UG' | 'US' | 'UY' | 'UZ' | 'VA' | 'VC' | 'VE' | 'VG' | 'VI' | 'VN' | 'VU' | 'WF' | 'WS' | 'XK' | 'YE' | 'YT' | 'ZA' | 'ZM' | 'ZW';
-export type Metadata = { country_calling_codes: { [countryCallingCode: string]: CountryCode[] }, countries: { [country: CountryCode]: any[] } };
+
+export type CountryCallingCodes = {
+  [countryCallingCode: string]: CountryCode[];
+};
+
+export type Countries = {
+  [country in CountryCode]: any[];
+};
+
+export type Metadata = {
+  country_calling_codes: CountryCallingCodes;
+  countries: Countries;
+};
 
 export type NumberFormat = 'NATIONAL' | 'National' | 'INTERNATIONAL' | 'International' | 'E.164' | 'RFC3966' | 'IDD';
 export type NumberType = undefined | 'PREMIUM_RATE' | 'TOLL_FREE' | 'SHARED_COST' | 'VOIP' | 'PERSONAL_NUMBER' | 'PAGER' | 'UAN' | 'VOICEMAIL' | 'FIXED_LINE_OR_MOBILE' | 'FIXED_LINE' | 'MOBILE';
@@ -9,12 +21,24 @@ export interface Extension extends String { }
 export interface CountryCallingCode extends String { }
 
 type FormatExtension = (number: string, extension: string, metadata: Metadata) => string
-type FormatNumberOptionsWithoutIDD = { v2?: boolean, formatExtension?: FormatExtension };
-// Legacy.
-export type FormatNumberOptions = { v2?: boolean, fromCountry?: CountryCode, humanReadable?: boolean, formatExtension?: FormatExtension };
+type FormatNumberOptionsWithoutIDD = {
+  v2?: boolean;
+  formatExtension?: FormatExtension;
+};
 
 // Legacy.
-export type ParseNumberOptions = { defaultCountry?: CountryCode, extended?: boolean }
+export type FormatNumberOptions = {
+  v2?: boolean;
+  fromCountry?: CountryCode;
+  humanReadable?: boolean;
+  formatExtension?: FormatExtension
+};
+
+// Legacy.
+export type ParseNumberOptions = {
+  defaultCountry?: CountryCode;
+  extended?: boolean;
+};
 
 export class PhoneNumber {
   constructor(countryCallingCodeOrCountry: CountryCallingCode | CountryCode, nationalNumber: NationalNumber, metadata: Metadata);


### PR DESCRIPTION
The index signature for type `Countries` cannot be a union type (e.g. `"US" | "UK" | ...`), we instead convert the syntax to `[country in Countries]` to satisfy the constraint. See https://github.com/Microsoft/TypeScript/issues/19768 for more info on why this cannot happen.