### PR TITLE
Fix missing type definitions when importing from subpackages

### DIFF
--- a/max/package.json
+++ b/max/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "index.commonjs.js",
   "module": "index.js",
+  "types": "../index.d.ts",
   "sideEffects": false
 }

--- a/min/package.json
+++ b/min/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "index.commonjs.js",
   "module": "index.js",
+  "types": "../index.d.ts",
   "sideEffects": false
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -4,5 +4,6 @@
   "version": "1.0.0",
   "main": "index.commonjs.js",
   "module": "index.js",
+  "types": "../index.d.ts",
   "sideEffects": false
 }


### PR DESCRIPTION
Explicitely point to the main type definition file from the subpackages `package.info` to allow types to be used when doing `import 'libphonenumber-js/{min,max,mobile}`.