### PR TITLE
Typings for parsePhoneNumberFromString are incorrect

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -62,13 +62,13 @@ export interface ParsedNumber {
 }
 
 export function parsePhoneNumber(text: string, defaultCountry?: CountryCode): PhoneNumber;
-export function parsePhoneNumberFromString(text: string, defaultCountry?: CountryCode): PhoneNumber;
+export function parsePhoneNumberFromString(text: string, defaultCountry?: CountryCode): PhoneNumber | undefined;
 
 // `parse()` and `parseCustom` are deprecated.
 // Use `fparseNumber()` and `parseNumberCustom()` instead.
 export function parse(text: string, options?: CountryCode | ParseNumberOptions): ParsedNumber;
 
-export function parseNumber(text: string, options?: CountryCode | ParseNumberOptions): ParsedNumber | undefined;
+export function parseNumber(text: string, options?: CountryCode | ParseNumberOptions): ParsedNumber;
 
 // `format()` and `formatCustom` are deprecated.
 // Use `formatNumber()` and `formatNumberCustom()` instead.

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ export function parsePhoneNumberFromString(text: string, defaultCountry?: Countr
 // Use `fparseNumber()` and `parseNumberCustom()` instead.
 export function parse(text: string, options?: CountryCode | ParseNumberOptions): ParsedNumber;
 
-export function parseNumber(text: string, options?: CountryCode | ParseNumberOptions): ParsedNumber;
+export function parseNumber(text: string, options?: CountryCode | ParseNumberOptions): ParsedNumber | undefined;
 
 // `format()` and `formatCustom` are deprecated.
 // Use `formatNumber()` and `formatNumberCustom()` instead.


### PR DESCRIPTION
According to docs, "Returns an instance of PhoneNumber class, or undefined if no phone number could be parsed". Typings updated accordingly.