### PR TITLE
Remove /source from .npmignore (for debugging with sourcemap)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,9 +5,6 @@
 # Babel
 .babelrc
 
-# Sources aren't needed for npm
-/source/
-
 # testing package
 /libphonenumber-js-*.tgz
 


### PR DESCRIPTION
libphonenumber-js publishes a sourcemap (good!) but doesn't publish the source code that the sourcemap points to. This makes debugging difficult since you can't set breakpoints or step into the library's original source code.  This PR removes the /source directory from .npmignore to enable easier debugging. 

Thanks! 