### PR TITLE
Fix argument type of `isSupportedCountry` helper

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -122,7 +122,7 @@ export function getCountryCallingCode(countryCode: CountryCode): CountryCallingC
 // Deprecated.
 export function getPhoneCode(countryCode: CountryCode): CountryCallingCode;
 export function getExtPrefix(countryCode: CountryCode): string;
-export function isSupportedCountry(countryCode: CountryCode): boolean;
+export function isSupportedCountry(countryCode: string): boolean;
 
 export function formatIncompletePhoneNumber(number: string, countryCode?: CountryCode): string;
 export function parseIncompletePhoneNumber(text: string): string;


### PR DESCRIPTION
Since the whole point of the helper is to check whether an arbitrary string is a valid country code supported by the library, we should accept any string here. For instance, the example code `isSupportedCountry("XX")` causes a compiler error, because "XX" is not part of the `CountryCode` union type.