### PR TITLE
Parse international phone number without plus sign correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ npm-debug.log
 /metadata.min.json.js
 /metadata.mobile.json.js
 /examples.mobile.json.js
+
+# idea ide
+.idea/

--- a/source/parse.test.js
+++ b/source/parse.test.js
@@ -67,6 +67,23 @@ describe('parse', () => {
 		parseNumber('07624369230', 'GB').should.deep.equal({ country: 'IM', phone: '7624369230' })
 	})
 
+	it('should parse valid phone numbers even without plus sign', () => {
+		// France
+		parseNumber('33169454850', 'FR').should.deep.equal({ country: 'FR', phone: '169454850' })
+
+		// Long country phone code.
+		parseNumber('212659777777', 'MA').should.deep.equal({ country: 'MA', phone: '659777777' })
+
+		// UK (Jersey)
+		parseNumber('44 7700 300000', 'JE').should.deep.equal({ country: 'JE', phone: '7700300000' })
+
+		// KZ
+		parseNumber('7 702 211 1111', 'KZ').should.deep.equal({ country: 'KZ', phone: '7022111111' })
+
+		// DE
+		parseNumber('49360777642', 'DE').should.deep.equal({ country: 'DE', phone: '360777642' })
+	})
+
 	it('should parse possible numbers', () => {
 		// Invalid phone number for a given country.
 		parseNumber('1112223344', 'RU', { extended: true }).should.deep.equal({

--- a/source/parsePhoneNumber.test.js
+++ b/source/parsePhoneNumber.test.js
@@ -26,6 +26,24 @@ describe('parsePhoneNumber', () => {
 		parsePhoneNumberFull('Phone: 8 (800) 555 35 35.', 'RU').getType().should.equal('TOLL_FREE')
 	})
 
+	it('should parse phone numbers even without plus sign', () => {
+		const phoneNumber1 = parsePhoneNumber('Phone: 33 1 69 45 48 50.', 'FR')
+		phoneNumber1.country.should.equal('FR')
+		phoneNumber1.countryCallingCode.should.equal('33')
+		phoneNumber1.nationalNumber.should.equal('169454850')
+		phoneNumber1.number.should.equal('+33169454850')
+		phoneNumber1.isPossible().should.equal(true)
+		phoneNumber1.isValid().should.equal(true)
+
+		const phoneNumber2 = parsePhoneNumber('Phone: 33 (0) 1 69 45 48 50.', 'FR')
+		phoneNumber2.country.should.equal('FR')
+		phoneNumber2.countryCallingCode.should.equal('33')
+		phoneNumber2.nationalNumber.should.equal('169454850')
+		phoneNumber2.number.should.equal('+33169454850')
+		phoneNumber2.isPossible().should.equal(true)
+		phoneNumber2.isValid().should.equal(true)
+	})
+
 	it('shouldn\'t set country when it\'s non-derivable', () => {
 		const phoneNumber = parsePhoneNumber('+7 111 555 35 35')
 		expect(phoneNumber.country).to.be.undefined


### PR DESCRIPTION
This should fix the issue #316 

With this example:
```javascript
let result = parseNumber('33169454850', 'FR', { extended: true });
console.log(result);
```
what I get:
```javascript
{
    country: 'FR',
    countryCallingCode: '33',
    carrierCode: undefined,
    valid: false,
    possible: false,
    phone: '33169454850',
    ext: undefined
}
```
what I should get:
```javascript
{
    country: 'FR',
    countryCallingCode: '33',
    carrierCode: undefined,
    valid: true,
    possible: true,
    phone: '169454850',
    ext: undefined
}
```
https://libphonenumber.appspot.com/phonenumberparser?number=33169454850&country=FR

available for any questions