### PR TITLE
Question regarding phone number code parsing

### DIFF
--- a/source/parsePhoneNumber.test.js
+++ b/source/parsePhoneNumber.test.js
@@ -70,7 +70,8 @@ describe('parsePhoneNumber', () => {
 		expect(() => parsePhoneNumber('8', 'RU')).to.throw('NOT_A_NUMBER')
 		// Won't throw here because the regexp already demands length > 1.
 		// expect(() => parsePhoneNumber('11', 'RU')).to.throw('TOO_SHORT')
-		expect(() => parsePhoneNumber('+443')).to.throw('TOO_SHORT')
+		expect(() => parsePhoneNumber('+443')).to.throw('INVALID_COUNTRY')
+		expect(() => parsePhoneNumber('+370')).to.throw('TOO_SHORT')
 		expect(() => parsePhoneNumber('88888888888888888888', 'RU')).to.throw('TOO_LONG')
 		expect(() => parsePhoneNumber('8 (800) 555 35 35')).to.throw('INVALID_COUNTRY')
 		expect(() => parsePhoneNumber('+9991112233')).to.throw('INVALID_COUNTRY')


### PR DESCRIPTION
1. `+443` throws as too short, however this code isn't present in metadata.
2. `+370` throws invalid country, however this code is in metadata.

Updated test according to my understanding.
1. Should throw INVALID_COUNTRY
2. Should throw TOO_SHORT

Is this an issue or I misunderstood how library should work? 