### PR TITLE
Update README.md - fix broken 'jsdelivr' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,7 +1070,7 @@ When reporting `findNumbers()` bugs one should know that `findNumbers()` code wa
 
 ## CDN
 
-One can use any npm CDN service, e.g. [unpkg.com](https://unpkg.com) or [jsdelivr.net](https://jsdelivr.net)
+One can use any npm CDN service, e.g. [unpkg.com](https://unpkg.com) or [jsdelivr.com](https://jsdelivr.com)
 
 ```html
 <script src="https://unpkg.com/libphonenumber-js@[version]/bundle/libphonenumber-[type].js"></script>


### PR DESCRIPTION
Changed link and reference from 'jsdelivr.net' to 'jsdelivr.com' at line 1073