### PR TITLE
National prefix option will respect false

### DIFF
--- a/source/format_.js
+++ b/source/format_.js
@@ -119,7 +119,7 @@ function formatNationalNumber(number, carrierCode, formatAs, metadata, options) 
 		format,
 		{
 			useInternationalFormat: formatAs === 'INTERNATIONAL',
-			withNationalPrefix: format.nationalPrefixIsOptionalWhenFormattingInNationalFormat() && (options && options.nationalPrefix === false) ? false : true,
+			withNationalPrefix: format.nationalPrefixIsOptionalWhenFormattingInNationalFormat() || (options && options.nationalPrefix === false) ? false : true,
 			carrierCode,
 			metadata
 		}


### PR DESCRIPTION
Thank you for maintaining this library, it has been great to work with! 
I am currently working with the formatNational method on a phone number input project. I do not want the nationalNumber prefix to show in my project. I found documentation on setting the option for nationalPrefix to false

```nationalPrefix: Boolean — Some phone numbers can be formatted both with national prefix and without it. In such cases the library defaults to "with national prefix" (for legacy reasons). Pass nationalPrefix: false option to force formatting without national prefix in such cases.```

When looking into the code I realized that  ```format.nationalPrefixIsOptionalWhenFormattingInNationalFormat()``` is always false when using a national number so passing in the option would never work. Then change I am submitting ot make this expression check for an || instead of && will make the formatter respect the nationalPrefix: false option 

