### PR TITLE
fix: AsYouType.getNumber() duplicates area code for single-area NANP territories

### DIFF
--- a/source/AsYouType.js
+++ b/source/AsYouType.js
@@ -4,6 +4,7 @@ import checkNumberLength from './helpers/checkNumberLength.js'
 import AsYouTypeState from './AsYouTypeState.js'
 import AsYouTypeFormatter, { DIGIT_PLACEHOLDER } from './AsYouTypeFormatter.js'
 import AsYouTypeParser, { extractFormattedDigitsAndPlus } from './AsYouTypeParser.js'
+import extractNationalNumberFromPossiblyIncompleteNumber from './helpers/extractNationalNumberFromPossiblyIncompleteNumber.js'
 import getCountryByCallingCode from './helpers/getCountryByCallingCode.js'
 import getCountryByNationalNumber from './helpers/getCountryByNationalNumber.js'
 import isObject from './helpers/isObject.js'
@@ -311,6 +312,41 @@ export default class AsYouType {
 		}
 	}
 
+	// Returns the national (significant) number that should be used when
+	// constructing a `PhoneNumber` or a E.164 value out of the user's input.
+	//
+	// While digits are being input one at a time, `state.nationalSignificantNumber`
+	// is extracted from a partial number, and once `national_prefix_for_parsing`
+	// has matched (and possibly applied a `national_prefix_transform_rule`), the
+	// result is cached and subsequent digits are simply appended to it.
+	// For some numbering plans the `national_prefix_for_parsing` pattern is
+	// end-anchored and matches an intermediate buffer that is itself a complete
+	// national number, which re-injects an area code that was already typed.
+	// For example, for `"VI"` the buffer `"3406934"` matches `"([2357]\d{6})$"`
+	// and gets transformed to `"3403406934"` via `"340$1"`, so further digits
+	// produce a national number with a duplicated area code.
+	// Re-extracting from the full national digits yields the same result as
+	// parsing the complete number in one pass, so it corrects that artifact while
+	// preserving legitimate transforms (such as Argentina's mobile prefix).
+	_getNationalNumber() {
+		const {
+			nationalSignificantNumber,
+			nationalSignificantNumberIsModified
+		} = this.state
+		if (
+			nationalSignificantNumberIsModified &&
+			!this.isInternational() &&
+			this.metadata.hasSelectedNumberingPlan()
+		) {
+			const { nationalNumber } = extractNationalNumberFromPossiblyIncompleteNumber(
+				this.state.getNationalDigits(),
+				this.metadata
+			)
+			return nationalNumber
+		}
+		return nationalSignificantNumber
+	}
+
 	/**
 	 * Returns a E.164 phone number value for the user's input.
 	 *
@@ -333,9 +369,10 @@ export default class AsYouType {
 		const {
 			digits,
 			callingCode,
-			country,
-			nationalSignificantNumber
+			country
 		} = this.state
+
+		const nationalSignificantNumber = this._getNationalNumber()
 
 	 	// Will return `undefined` if no digits have been input.
 		if (!digits) {
@@ -364,10 +401,11 @@ export default class AsYouType {
 	 */
 	getNumber() {
 		const {
-			nationalSignificantNumber,
 			carrierCode,
 			callingCode
 		} = this.state
+
+		const nationalSignificantNumber = this._getNationalNumber()
 
 		if (!nationalSignificantNumber) {
 			return

--- a/source/AsYouType.test.js
+++ b/source/AsYouType.test.js
@@ -823,6 +823,24 @@ describe('AsYouType', () => {
 		expect(asYouType.input('123')).to.equal('(340) 693-4123')
 	})
 
+	it('should not duplicate area code in the parsed number when typing digit by digit (single-area-code countries)', () => {
+		// https://github.com/catamphetamine/libphonenumber-js/issues/318
+		// The formatted output was already correct, but `getNumber()` used to
+		// return a national number with the area code duplicated, because the
+		// end-anchored `national_prefix_for_parsing` matched an intermediate
+		// 7-digit buffer and prepended the area code that was already typed.
+		for (const [country, input] of [['VI', '3406934123'], ['TT', '8686941234']]) {
+			const asYouType = new AsYouType(country)
+			for (const digit of input) {
+				asYouType.input(digit)
+			}
+			const phoneNumber = asYouType.getNumber()
+			expect(phoneNumber.nationalNumber).to.equal(input)
+			expect(phoneNumber.isValid()).to.equal(true)
+			expect(asYouType.getNumberValue()).to.equal('+1' + input)
+		}
+	})
+
 	it('shouldn\'t throw when passed a non-existent default country', () => {
 		expect(new AsYouType('XX').input('+78005553535')).to.equal('+7 800 555 35 35')
 		expect(new AsYouType('XX').input('88005553535')).to.equal('88005553535')


### PR DESCRIPTION
## Problem

When a valid national number is typed one digit at a time for a single-area-code NANP territory, `AsYouType.getNumber()` returns a `PhoneNumber` whose `nationalNumber` has the area code duplicated. The formatted display string is correct; only the parsed number is wrong, so the bug is latent.

```js
const { AsYouType, parsePhoneNumber } = require('libphonenumber-js')

const ayt = new AsYouType('VI')
for (const ch of '3406934123') ayt.input(ch)

ayt.input('')                  // display was '(340) 693-4123'  (correct)
ayt.getNumber().nationalNumber // => '3403406934123'  (340 doubled, 13 digits)
ayt.getNumber().isValid()      // => false
ayt.getNumberValue()           // => '+13403406934123'

parsePhoneNumber('3406934123', 'VI').nationalNumber // => '3406934123'  (correct)
```

This violates the contract stated in the source itself (`AsYouType.js`): `getNumber()` is meant to be a 1:1 equivalent of `parsePhoneNumber(getNumberValue())`. The anchor here is digit preservation, not a validity opinion: the input is valid both in this library and in Google's reference `google-libphonenumber`, and feeding the whole string in one `input()` call already returns the correct `3406934123`.

## Affected territories

All 14 single-area-code NANP territories, each doubling its own area code: AI, AS, BB, BM, DM, GD, GU, KY, LC, MP, TT, VC, VG, VI (area codes 264, 684, 246, 441, 767, 473, 671, 345, 758, 670, 868, 784, 284, 340).

## Root cause

For these territories `national_prefix_for_parsing` is end-anchored, e.g. VI uses `([2357]\d{6})$|1` with `national_prefix_transform_rule` `340$1`. During incremental input, the moment the running national buffer is exactly the first 7 digits (`3406934`), it matches `^([2357]\d{6})$`, the transform fires and prepends `340`, so `state.nationalSignificantNumber` becomes `3403406934`. Subsequent keystrokes are appended to that value and the parser never re-derives a clean national number from the full buffer.

The display path already recovers from this through the `nationalSignificantNumberIsModified` flag (it falls back to the typed national digits), which is why the formatted string stays correct and the existing test for issue #318 (`AsYouType.test.js`, display-only assertions) does not catch it. But `getNumber()` and `getNumberValue()` read the raw, modified `state.nationalSignificantNumber` directly.

## Fix

When the national significant number was modified during incremental input and the number is being entered in national format, `getNumber()` and `getNumberValue()` now re-extract the national number from the full national digits (`_getNationalNumber()`). Re-extracting from the complete buffer yields the same result as parsing the number in one pass, so it removes the duplicated area code while preserving legitimate transforms such as Argentina's mobile prefix (`0343515551212999` -> `93435551212999`) and carrier codes (BR). The shared parser helper is not modified, so the one-shot `parsePhoneNumber()` path is untouched.

## Tests

Added a regression test next to the existing issue #318 test that types VI and TT numbers digit by digit and asserts `getNumber().nationalNumber`, `getNumber().isValid()` and `getNumberValue()` (the previous test only asserted the display string). The test fails on master (`expected '3403406934123' to equal '3406934123'`) and passes with the fix. The full existing suite stays green (546 passing). No metadata was regenerated or committed.
